### PR TITLE
Add CLT column to member table

### DIFF
--- a/migrations/2019_11_04_165426_addclt.py
+++ b/migrations/2019_11_04_165426_addclt.py
@@ -7,7 +7,7 @@ class Addclt(Migration):
         Run the migrations.
         """
         with self.schema.table("member") as table:
-            table.boolean("clt").default(0)
+            table.boolean("is_clt").default(0)
             pass
 
     def down(self):
@@ -15,5 +15,5 @@ class Addclt(Migration):
         Revert the migrations.
         """
         with self.schema.table("member") as table:
-            table.drop_column("clt")
+            table.drop_column("is_clt")
             pass

--- a/migrations/2019_11_04_165426_addclt.py
+++ b/migrations/2019_11_04_165426_addclt.py
@@ -1,0 +1,19 @@
+from orator.migrations import Migration
+
+
+class Addclt(Migration):
+    def up(self):
+        """
+        Run the migrations.
+        """
+        with self.schema.table("member") as table:
+            table.boolean("clt").default(0)
+            pass
+
+    def down(self):
+        """
+        Revert the migrations.
+        """
+        with self.schema.table("member") as table:
+            table.drop_column("clt")
+            pass


### PR DESCRIPTION
I took the liberty of adding a 'CLT' column to our member table to improve our query building in Metabase. We have some indicators that take into account whether the member works 20ha (intern contract) or 22ha (CLT contract), and it would be really nice if this information was coming straight from the DB instead of figuring it out in the query.