### PR TITLE
Change company projects to standard format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,4 +155,5 @@ dmypy.json
 .DS_Store
 
 # Path with olds timesheets
-/old_timesheet_migration/timesheets/*
+/old_timesheet_migration/timesheets/*.csv
+/old_timesheet_migration/timesheets/*.xlsx

--- a/old_timesheet_migration/timesheet_migration.py
+++ b/old_timesheet_migration/timesheet_migration.py
@@ -54,8 +54,8 @@ def row_valid(project_name, activity_name, client_name, no_time_projects):
 def fix_row(project_name, activity_name, client_name, no_time_projects):
     """Returns project, activity and client name in a dict."""
     if project_name[0] in ["C", "E", "N", "T", "B", "W"]:
-        project_number = project_name.split(".",1)[1]
-        project_name = project_name[0]+(3-len(project_number))*'0'+project_number
+        project_number = project_name.split(".", 1)[1]
+        project_name = project_name[0] + project_number.zfill(3)
 
     names = {"project": project_name.lower()}
     if names["project"] in no_time_projects:

--- a/old_timesheet_migration/timesheet_migration.py
+++ b/old_timesheet_migration/timesheet_migration.py
@@ -53,6 +53,9 @@ def row_valid(project_name, activity_name, client_name, no_time_projects):
 
 def fix_row(project_name, activity_name, client_name, no_time_projects):
     """Returns project, activity and client name in a dict."""
+    if project_name[0] in ["C", "E", "N", "T", "B", "W"]:
+        project_number = project_name.split(".",1)[1]
+        project_name = project_name[0]+(3-len(project_number))*'0'+project_number
 
     names = {"project": project_name.lower()}
     if names["project"] in no_time_projects:


### PR DESCRIPTION
Fixes #52 

Company project names are different in Clockify and in old timesheets. If those names are not changed to be the same there would be duplicated projects.

I changed the old timesheets migration script to conform to the Clockify project naming conventions (e.g. WEG.101 to w101).