### PR TITLE
Feat/new timesheet structure

### DIFF
--- a/migrations/2020_03_05_040213_add_client_to_project_table.py
+++ b/migrations/2020_03_05_040213_add_client_to_project_table.py
@@ -7,7 +7,7 @@ class AddClientToProjectTable(Migration):
         Run the migrations.
         """
         with self.schema.table("project") as table:
-            table.integer("client_id").unsigned()
+            table.integer("client_id").unsigned().nullable()
             table.foreign("client_id").references("id").on("client")
 
     def down(self):

--- a/migrations/2020_03_05_040213_add_client_to_project_table.py
+++ b/migrations/2020_03_05_040213_add_client_to_project_table.py
@@ -1,0 +1,18 @@
+from orator.migrations import Migration
+
+
+class AddClientToProjectTable(Migration):
+    def up(self):
+        """
+        Run the migrations.
+        """
+        with self.schema.table("project") as table:
+            table.integer("client_id").unsigned()
+            table.foreign("client_id").references("id").on("client")
+
+    def down(self):
+        """
+        Revert the migrations.
+        """
+        with self.schema.table("project") as table:
+            table.drop_column("client_id")

--- a/models/activity.py
+++ b/models/activity.py
@@ -62,3 +62,13 @@ class Activity(Model):
             {"clockify_id": project["id"], "name": project["name"].lower()}
             for project in responses.json()
         ]
+
+    @staticmethod
+    def map_all_activities():
+        """Returns a dictionary of all activities in database. Dictionary key is activity
+           name. This should be used to reduce Queries to our DB in other functions."""
+
+        activities_map = {}
+        for activity in Activity.all():
+            activities_map[activity.name] = {"id": activity.id}
+        return activities_map

--- a/models/client.py
+++ b/models/client.py
@@ -1,6 +1,4 @@
 from models import *
-
-
 import requests
 
 
@@ -13,23 +11,23 @@ class Client(Model):
 
     @classmethod
     def save_from_clockify(cls):
-        """Check if all tags in clockify are register as clients in the database.
+        """Check if all clients in clockify are register as clients in the database.
         Create a new client if necessary."""
-        tags = cls.fetch_all_tags()
-        for tag in tags:
+        clients = cls.fetch_all_clients()
+        for client in clients:
             Client.update_or_create(
-                {"clockify_id": tag["clockify_id"]}, {"name": tag["name"]}
+                {"clockify_id": client["clockify_id"]}, {"name": client["name"]}
             )
-        return tags
+        return clients
 
     @staticmethod
-    def fetch_all_tags():
-        """Find all tags from Clockify on NEO's workspace.
+    def fetch_all_clients(archived=None):
+        """Find all clients from Clockify on NEO's workspace.
 
         Returns list of dictionaries containing "clockify_id" and "name"
-        of every tag."""
+        of every client."""
 
-        url = "{}/workspaces/{}/tags".format(V1_API_URL, WORKSPACE_ID)
+        url = "{}/workspaces/{}/clients".format(V1_API_URL, WORKSPACE_ID)
         responses = requests.get(url, headers=HEADERS)
         return [
             {"clockify_id": client["id"], "name": client["name"].lower()}

--- a/models/client.py
+++ b/models/client.py
@@ -33,3 +33,13 @@ class Client(Model):
             {"clockify_id": client["id"], "name": client["name"].lower()}
             for client in responses.json()
         ]
+
+    @staticmethod
+    def map_all_clients():
+        """Returns a dictionary of all clients in database. Dictionary key is client
+           clockify id. This should be used to reduce Queries to our DB in other functions."""
+
+        clients_map = {}
+        for client in Client.all():
+            clients_map[client.clockify_id] = {"id": client.id, "name": client.name}
+        return clients_map

--- a/models/member.py
+++ b/models/member.py
@@ -39,3 +39,17 @@ class Member(Model):
             }
             for user in responses.json()
         ]
+
+    @staticmethod
+    def map_all_members():
+        """Returns a dictionary of all members in database. Dictionary key is member
+           clockify id. This should be used to reduce Queries to our DB in other functions."""
+
+        members_map = {}
+        for member in Member.all():
+            members_map[member.clockify_id] = {
+                "id": member.id,
+                "acronym": member.acronym,
+                "email": member.email,
+            }
+        return members_map

--- a/models/project.py
+++ b/models/project.py
@@ -28,10 +28,13 @@ class Project(Model):
             pass
 
     @classmethod
-    def save_from_clockify(cls):
+    def save_from_clockify(cls, archived=0):
         """Check if all projects in clockify are register as projects in the database.
-        Create a new project if necessary."""
-        projects = cls.fetch_all_projects()
+           Create a new project if necessary.
+           Use the parameter archived="" to retrieve all projects.
+           Use the parameter archived=0 to retrieve all active projects.
+           Use the parameter archived=1 to retrieve all archived projects."""
+        projects = cls.fetch_all_projects(archived)
         clients_dict = Client.map_all_clients()
         for project in projects:
             Project.update_or_create(
@@ -46,11 +49,11 @@ class Project(Model):
     @staticmethod
     def fetch_all_projects(archived=0):
         """Find all projects on NEO's workspace.
-        Use the parameter archived="" to retrieve all projects.
-        Use the parameter archived=0 to retrieve all active projects.
-        Use the parameter archived=1 to retrieve all archived projects.
-        Returns list of dictionaries containing "name", "clockify_id"
-        for every project."""
+           Use the parameter archived="" to retrieve all projects.
+           Use the parameter archived=0 to retrieve all active projects.
+           Use the parameter archived=1 to retrieve all archived projects.
+           Returns list of dictionaries containing "name", "clockify_id"
+           for every project."""
 
         url = "{}/workspaces/{}/projects?page-size=100&archived={}"
         url = url.format(V1_API_URL, WORKSPACE_ID, archived)

--- a/models/project.py
+++ b/models/project.py
@@ -1,19 +1,21 @@
 from models import *
-from orator.orm import belongs_to_many
+from orator.orm import belongs_to_many, belongs_to
 import requests
 
 
 class Project(Model):
 
     __table__ = "project"
-    __fillable__ = ["clockify_id", "name"]
+    __fillable__ = ["clockify_id", "client_id", "name",]
     __primary_key__ = "id"
     __incrementing__ = True
 
+    @belongs_to("client_id", "id")
+    def client(self):
+        return Client
+
     @belongs_to_many("project_activity", "project_id", "activity_id")
     def activities(self):
-        from models import Activity
-
         return Activity
 
     @classmethod

--- a/models/project.py
+++ b/models/project.py
@@ -66,3 +66,17 @@ class Project(Model):
             }
             for project in responses.json()
         ]
+
+    @staticmethod
+    def map_all_projects():
+        """Returns a dictionary of all projects in database. Dictionary key is project
+           clockify id. This should be used to reduce Queries to our DB in other functions."""
+
+        projects_map = {}
+        for project in Project.all():
+            projects_map[project.clockify_id] = {
+                "id": project.id,
+                "name": project.name,
+                "client_id": project.client_id,
+            }
+        return projects_map

--- a/models/project.py
+++ b/models/project.py
@@ -6,7 +6,7 @@ import requests
 class Project(Model):
 
     __table__ = "project"
-    __fillable__ = ["clockify_id", "client_id", "name",]
+    __fillable__ = ["clockify_id", "client_id", "name"]
     __primary_key__ = "id"
     __incrementing__ = True
 
@@ -32,9 +32,14 @@ class Project(Model):
         """Check if all projects in clockify are register as projects in the database.
         Create a new project if necessary."""
         projects = cls.fetch_all_projects()
+        clients_dict = Client.map_all_clients()
         for project in projects:
             Project.update_or_create(
-                {"clockify_id": project["clockify_id"]}, {"name": project["name"]}
+                {"clockify_id": project["clockify_id"]},
+                {
+                    "client_id": clients_dict[project["client_id"]]["id"],
+                    "name": project["name"],
+                },
             )
         return projects
 
@@ -51,6 +56,10 @@ class Project(Model):
         url = url.format(V1_API_URL, WORKSPACE_ID, archived)
         responses = requests.get(url, headers=HEADERS)
         return [
-            {"name": project["name"].lower(), "clockify_id": project["id"]}
+            {
+                "name": project["name"].lower(),
+                "clockify_id": project["id"],
+                "client_id": project["clientId"],
+            }
             for project in responses.json()
         ]

--- a/services/populate.py
+++ b/services/populate.py
@@ -8,4 +8,4 @@ if __name__ == "__main__":
     Client.save_from_clockify()
     Project.save_from_clockify(archived="")
     Activity.save_from_clockify()
-    TimeEntry.save_from_clockify()
+    TimeEntry.save_from_clockify(start="2020-03-01T00:00:01Z")

--- a/services/populate.py
+++ b/services/populate.py
@@ -5,7 +5,7 @@ from models import Activity, Client, Member, Project, TimeEntry
 
 if __name__ == "__main__":
     Member.save_from_clockify()
-    Project.save_from_clockify()
-    Activity.save_from_clockify()
     Client.save_from_clockify()
+    Project.save_from_clockify(archived="")
+    Activity.save_from_clockify()
     TimeEntry.save_from_clockify()


### PR DESCRIPTION
# New Timesheet Structure
## What is this about?
This PR changes the models and structure of our database to the new timesheet structure proposed by LAB and approved by DFG, YAB, and VRN. Now tags are not necessary and the client is always the client of a project set in clockify. This makes life a lot easier for who is appointing time and also for developers in clockify_integration :).

Time spent with insert now is ~0.15s for each time entry (~10x faster than the older method). 

## What changed?

Now the project model and table have the client associated with it. I didn't remove the client from the Timeentry model and table so the script developed by @yvesfracari will still work.

Now every model has a function to create a dictionary with all info regarding that model. This is used to speed up the time_entry inserts. A lot fewer queries are made now because of this.